### PR TITLE
Optionally enforce SNS Topic Policy for CW Events

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,9 @@ variable "sns_topic_name" {
   type        = "string"
   description = "The name of the SNS topic to send root login notifications."
 }
+
+variable "enforce_sns_policy" {
+  type = bool
+  default = false
+  description = "If enabled will enforce the SNS topic access policy to ensure events are allowed to be published."
+}


### PR DESCRIPTION
This PR is to optionally enforce the SNS Topic Access Policy to allow CW Events to send messages when a CW rule is fired.

Since modifying the access policy makes an assumption that the policy isn't managed, currently not via `aws-notify-slack module,` this is optional and defaults to not manage to no step on other configuration.

Snippet of sns policy being applied
```
Terraform will perform the following actions:

  # module.root_login_notifications.aws_sns_topic_policy.default[0] will be created
  + resource "aws_sns_topic_policy" "default" {
      + arn    = "arn:aws:sns:us-east-1:XXX:slack-alerts"
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Id        = "PolicyId"
              + Statement = [
                  + {
                      + Action    = "SNS:Publish"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "events.amazonaws.com"
                        }
                      + Resource  = "arn:aws:sns:us-east-1:XXX:slack-alerts"
                      + Sid       = "CloudWatchEvents"
                    },
                  + {
                      + Action    = [
                          + "SNS:Subscribe",
                          + "SNS:SetTopicAttributes",
                          + "SNS:RemovePermission",
                          + "SNS:Receive",
                          + "SNS:Publish",
                          + "SNS:ListSubscriptionsByTopic",
                          + "SNS:GetTopicAttributes",
                          + "SNS:DeleteTopic",
                          + "SNS:AddPermission",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + AWS:SourceOwner = "XXX"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:sns:us-east-1:XXX:slack-alerts"
                      + Sid       = "SlackAlertDefaultPolicy"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }
```