### PR TITLE
Adding CW Event metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,34 @@ module "root-login-notifications" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| send\_sns | If true will send message *Successful AWS console login with the root account* to SNS topic | bool | `"false"` | no |
+| send\_sns | If true will send message \*Successful AWS console login with the root account\* to SNS topic | bool | `"false"` | no |
 | sns\_topic\_name | The name of the SNS topic to send root login notifications. | string | n/a | yes |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+
+## PagerDuty Setup
+
+There are two methods to generate root logins alerts in PagerDuty.
+
+### Method 1: CloudWatch Rule
+
+Use this method if already have a SNS topic handling existing CW Events.
+
+1. In TF or manually create a PagerDuty CloudWatch [integration](https://support.pagerduty.com/docs/aws-cloudwatch-integration-guide#section-integrating-with-a-pager-duty-service)
+1. In TF ensure that the PagerDuty endpoint provided is assigned/subscribed to the SNS topic. For more info see the AWS topic about the proper [policy](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CWE_Troubleshooting.html#RuleTriggeredMoreThanOnce).
+1. Apply this module to the SNS topic.
+1. Test by logging in as root
+
+
+
+### Method 2: Custom PagerDuty Event
+
+Use this method if wishing to have a dedicated SNS topic for PagerDuty alerts or custom message parsing for advanced PagerDuty features.
+
+1. In TF or manually create a PagerDuty [Custom Event Transformer](https://v2.developer.pagerduty.com/docs/cet) CloudWatch
+1. In TF ensure that the PagerDuty endpoint provided is assigned/subscribed to the SNS topic. For more info see the AWS topic about the proper [policy](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CWE_Troubleshooting.html#RuleTriggeredMoreThanOnce).
+1. Apply this module to the SNS topic with the `send_sns = true` and customizing the [input_template](https://github.com/trussworks/terraform-aws-root-login-notifications/blob/master/main.tf#L46) as needed.
+1. Test by logging in as root
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Enables notifications to an SNS topic when someone successfully logs in using th
 Creates the following resources:
 
 * CloudWatch event rule to filter for console logins with the root account.
-* CloudWatch event target to send notifications to an SNS topic.
+* CloudWatch metric to trigger CW event when console rule is triggered
+* CloudWatch event target to send notifications to an SNS topic. (optional)
 
 ## Usage
 
@@ -22,6 +23,7 @@ module "root-login-notifications" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| send\_sns | If true will send message *Successful AWS console login with the root account* to SNS topic | bool | `"false"` | no |
 | sns\_topic\_name | The name of the SNS topic to send root login notifications. | string | n/a | yes |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -38,12 +38,32 @@ resource "aws_cloudwatch_event_rule" "main" {
 }
 
 resource "aws_cloudwatch_event_target" "main" {
+  count     = var.send_sns ? 1 : 0
   rule      = aws_cloudwatch_event_rule.main.name
   target_id = "send-to-sns"
   arn       = data.aws_sns_topic.main.arn
 
   input_transformer {
     input_template = "\"Successful AWS console login with the root account.\""
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm_cwe_triggered" {
+  alarm_name          = "iam-root-login-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  datapoints_to_alarm = "1"
+  metric_name         = "TriggeredRules"
+  namespace           = "AWS/Events"
+  period              = "300"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "IAM Root Login CW Rule has been triggered"
+  alarm_actions       = [data.aws_sns_topic.main.arn]
+  ok_actions          = [data.aws_sns_topic.main.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.main.name
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,8 @@ variable "sns_topic_name" {
   description = "The name of the SNS topic to send root login notifications."
 }
 
+variable "send_sns" {
+  type        = bool
+  default     = false
+  description = "If true will send message *Successful AWS console login with the root account* to SNS topic"
+}


### PR DESCRIPTION
This PR is to add a CW Alarm to monitor when the CW Rule of Root Login is triggered.

Why?
When using PagerDuty the integration is from SNS Topic -> PagerDuty (PD). PD is expecting a CW Event json payload. Sending the message via `input_template = "\"Successful AWS console login with the root account.\""` PD silently discards and no notification.

If one wishes to continue to use the `input_template = "\"Successful AWS console login with the root account.\""`  then a SNS topic will need to be setup with a target of PD https://v2.developer.pagerduty.com/docs/cet and setting `send_sns` to true.