### PR TITLE
Adding alarm suffix variable for identifying flagged account

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ module "root-login-notifications" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| send\_sns | If true will send message \*Successful AWS console login with the root account\* to SNS topic | bool | `"false"` | no |
+| alarm\_suffix | Suffix to add to alarm name, used for separating different AWS account. | string | `""` | no |
+| send\_sns | If true will send message *Successful AWS console login with the root account* to SNS topic | bool | `"false"` | no |
 | sns\_topic\_name | The name of the SNS topic to send root login notifications. | string | n/a | yes |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module "root-login-notifications" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alarm\_suffix | Suffix to add to alarm name, used for separating different AWS account. | string | `""` | no |
-| send\_sns | If true will send message *Successful AWS console login with the root account* to SNS topic | bool | `"false"` | no |
+| send\_sns | If true will send message \*Successful AWS console login with the root account\* to SNS topic | bool | `"false"` | no |
 | sns\_topic\_name | The name of the SNS topic to send root login notifications. | string | n/a | yes |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_event_target" "main" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_cwe_triggered" {
-  alarm_name          = "iam-root-login-alarm"
+  alarm_name          = var.alarm_suffix == "" ? "iam-root-login-alarm" : "iam-root-login-alarm-${var.alarm_suffix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   datapoints_to_alarm = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,9 @@ variable "send_sns" {
   default     = false
   description = "If true will send message *Successful AWS console login with the root account* to SNS topic"
 }
+
+variable "alarm_suffix" {
+  type        = string
+  default     = ""
+  description = "Suffix to add to alarm name, used for separating different AWS account."
+}


### PR DESCRIPTION
This PR is to add an option for setting an CW alarm suffix. This helps with the confusion of managing more than one AWS account and slack notification becomes unclear which root login was detected.

Related Issue: https://github.com/trussworks/terraform-aws-root-login-notifications/issues/5

## Testing
Existing deployment of root notification

```
$ terraform plan
No changes. Infrastructure is up-to-date.
```

Setting variable `alarm_suffix = testing-account`
```

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.root_login_notifications.aws_cloudwatch_metric_alarm.alarm_cwe_triggered must be replaced
-/+ resource "aws_cloudwatch_metric_alarm" "alarm_cwe_triggered" {
        actions_enabled                       = true
        alarm_actions                         = [
            "arn:aws:sns:XXXX:XXXXX:infra-alerts",
        ]
        alarm_description                     = "IAM Root Login CW Rule has been triggered"
      ~ alarm_name                            = "iam-root-login-alarm" -> "iam-root-login-alarm-testing-account" # forces replacement
      ~ arn                                   = "arn:aws:cloudwatch:XXXX:XXXX:alarm:iam-root-login-alarm" -> (known after apply)
        comparison_operator                   = "GreaterThanOrEqualToThreshold"
        datapoints_to_alarm                   = 1
        dimensions                            = {
            "RuleName" = "iam-root-login"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
        evaluation_periods                    = 1
      ~ id                                    = "iam-root-login-alarm" -> (known after apply)
      - insufficient_data_actions             = [] -> null
        metric_name                           = "TriggeredRules"
        namespace                             = "AWS/Events"
        ok_actions                            = [
            "arn:aws:sns:XXXX:XXXX:infra-alerts",
        ]
        period                                = 300
        statistic                             = "Maximum"
      - tags                                  = {} -> null
        threshold                             = 1
        treat_missing_data                    = "missing"
    }

Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------

```
